### PR TITLE
Add project infrastructure and Rust-core architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,224 +1,141 @@
 # LoveWords
 
-**Communication is a human right. LoveWords exists to make it accessible to everyone.**
+> *"Find the words to say 'I love you, mom.'"*
 
-LoveWords is a free, open-source Augmentative and Alternative Communication (AAC) application designed to give voice to those who communicate differently. Whether you're a child learning to express yourself, an adult navigating aphasia, or a caregiver supporting a loved one, LoveWords is here for you.
-
----
-
-## Our Mission
-
-> *Every person deserves to be heard, understood, and connected.*
-
-LoveWords is built on a simple belief: the ability to communicate shouldn't depend on your income, location, or the device you own. We're creating AAC software that is **free forever**, **works offline**, and **adapts to the unique needs of every user**.
-
-This isn't just an app. It's a bridge between thoughts and expression, between isolation and connection, between silence and being truly heard.
+**LoveWords** is a free, open-source AAC tool for the words that matter most: love, gratitude, comfort, apology, and connection.
 
 ---
 
-## Core Pillars
+## Mission
 
-### 1. Free & Open Source
-Communication tools shouldn't cost thousands of dollars. LoveWords is and always will be free, licensed under GPL-3.0. The code belongs to the community, ensuring no one can lock away access to something so fundamental.
-
-### 2. Privacy First
-Your words are yours. LoveWords works completely offline. No accounts required. No data collection. No tracking. What you communicate stays between you and the people you're talking to.
-
-### 3. Truly Accessible
-Built from the ground up with accessibility as a core feature, not an afterthought. We support switch scanning, eye gaze integration, touch, and keyboard navigation. LoveWords adapts to you, not the other way around.
-
-### 4. Customizable & Personal
-Every communicator is unique. LoveWords offers deep customization: create your own symbol boards, record personal voice messages, adjust layouts, colors, and interaction methods. Your communication tool should feel like *yours*.
-
-### 5. Community Driven
-Built by and for the AAC community. We actively involve AAC users, speech-language pathologists, caregivers, and families in every stage of development. Nothing about us without us.
+**Give every AAC user an easy, dignified way to express heartfelt connection—especially the words that matter most to family.**
 
 ---
 
-## Who Is LoveWords For?
+## Who It's For
 
-LoveWords is designed for anyone who needs support with verbal communication:
-
-- **Children** with autism, cerebral palsy, Down syndrome, or developmental delays who are learning to communicate
-- **Adults** experiencing acquired conditions like ALS, stroke, aphasia, or traumatic brain injury
-- **Individuals** with selective mutism, social anxiety, or who are non-speaking by choice
-- **Temporary users** recovering from surgery, illness, or injury affecting speech
-- **Caregivers & families** supporting loved ones on their communication journey
-- **Speech-language pathologists** and educators seeking quality tools for their clients and students
-
-Whether communication support is a lifelong need or a temporary bridge, LoveWords is here.
+- **AAC users** who want fast access to relationship language—including nonspeaking and minimally speaking autistic people
+- **Families** who want to hear "I love you," "thank you," and "I'm sorry" from someone they love
+- **Therapists, educators, and caregivers** who support emotional expression and connection
 
 ---
 
-## Why LoveWords? What Makes Us Different
+## Why LoveWords?
 
-The AAC landscape has long been dominated by expensive proprietary software and locked ecosystems. Here's why we're building something different:
+### Relationship-First
+Many AAC tools focus on needs: *eat, drink, help.* LoveWords starts from connection: *I love you. I miss you. Thank you. I'm proud of you.* The emotional vocabulary that changes families.
 
-| Challenge | LoveWords Approach |
-|-----------|-------------------|
-| **Cost barrier** | Completely free. No subscriptions. No premium tiers. No hidden costs. |
-| **Internet dependency** | Works 100% offline. Use it anywhere: home, school, outdoors, hospitals. |
-| **Privacy concerns** | Zero data collection. No accounts. Your communication is private. |
-| **Limited customization** | Deep personalization options. Create symbols, record voices, design layouts. |
-| **Platform lock-in** | Cross-platform: web, mobile, desktop. Your boards go where you go. |
-| **Complex interfaces** | Clean, intuitive design. Easy setup for caregivers. Grows with the user. |
-| **Isolated development** | Community-driven. AAC users shape the roadmap. |
+### Works Immediately
+No complex setup. No weeks of configuration. A parent should be able to hand this to their child and watch them say "I love you, grandma" in minutes.
 
-### Our Commitment
+### Open and Portable
+Your boards belong to you. Export them, share them, remix them. No vendor lock-in. No proprietary formats.
 
-We will never:
-- Charge for core functionality
-- Sell or monetize user data
-- Create artificial limitations to push upgrades
-- Abandon the project or make it proprietary
+### Private by Default
+No accounts required. No tracking. Works offline. The words between you and your family stay between you.
+
+### Designed for Real Moments
+Bedtime. Goodbyes. Apologies. Celebrations. Missing someone. We build for the moments when the right words matter most.
 
 ---
 
-## MVP Features
+## What It Does
 
-Our Minimum Viable Product focuses on what matters most: **getting words out**.
+LoveWords provides simple, dependable communication boards focused on relationship language:
 
-### Core Communication
-- **Symbol-based communication boards** with high-quality, open-licensed symbols
-- **Text-to-speech** with multiple voice options and adjustable speech rate
-- **Word and phrase prediction** to speed up communication
-- **Quick phrases** for frequently used expressions ("I need help", "Yes", "No")
-- **Keyboard input** for literate users who prefer typing
+- **Love & Affection** — *I love you, you're my favorite, big hugs*
+- **Gratitude** — *Thank you, I appreciate you, you helped me*
+- **Comfort & Reassurance** — *It's okay, I'm here, you're safe*
+- **Apology & Repair** — *I'm sorry, can we start over, I still love you*
+- **Missing Someone** — *I miss you, wish you were here, thinking of you*
+- **Moments** — Quick boards for bedtime, goodbye, celebration, and overwhelm
 
-### Accessibility
-- **Switch scanning** with adjustable timing and patterns
-- **High contrast modes** and customizable color themes
-- **Large touch targets** with configurable sizes
-- **Auditory feedback** and visual confirmation
-- **Screen reader compatibility**
-
-### Customization
-- **Editable boards** - add, remove, and rearrange symbols
-- **Personal vocabulary** - add custom words and phrases
-- **Photo symbols** - use personal photos alongside standard symbols
-- **Voice recording** - record messages in a familiar voice
-- **Multiple profiles** - different setups for home, school, or therapy
-
-### Technical
-- **Works offline** - no internet required after initial setup
-- **Cross-platform** - web app works on any modern device
-- **Data export/import** - backup and share board configurations
-- **Lightweight** - fast loading, minimal storage requirements
+Personalize with photos of your people, recorded messages in familiar voices, and phrases that fit your family.
 
 ---
 
-## Accessibility Principles
+## Principles
 
-Accessibility isn't a feature we add later. It's the foundation we build on.
+| Principle | What It Means |
+|-----------|---------------|
+| **Free forever** | No cost, no subscriptions, no premium tiers |
+| **Privacy-first** | No tracking, no accounts, works offline |
+| **Open source** | Community-owned, transparent, forkable |
+| **Accessible** | Switch scanning, eye gaze, touch, keyboard |
+| **Inclusive** | All family structures, cultures, languages |
+| **Portable** | Your boards go where you go |
 
-### Our Standards
+---
 
-1. **WCAG 2.1 AA Compliance** (minimum) - We meet or exceed web accessibility guidelines
-2. **Motor accessibility** - Full functionality via switch access, eye gaze, touch, mouse, or keyboard
-3. **Visual accessibility** - High contrast options, scalable interfaces, screen reader support
-4. **Cognitive accessibility** - Consistent layouts, clear symbols, predictable interactions
-5. **Auditory feedback** - Sound cues to confirm actions for users who benefit from audio
+## First Boards
 
-### Input Methods We Support
+The starter set ships with boards for:
 
-- Touch (single tap, tap-and-hold, swipe)
-- Switch scanning (1-switch, 2-switch, row-column)
-- Eye gaze tracking (compatible with popular eye trackers)
-- Keyboard navigation (full Tab/Enter access)
-- Mouse/pointer with dwell selection option
+1. **Love & Affection** — express love in many ways
+2. **Gratitude & Appreciation** — say thank you meaningfully
+3. **Comfort & Reassurance** — support and be supported
+4. **Apology & Repair** — make things right
+5. **Missing Someone** — bridge distance and absence
+6. **Moments** — bedtime, goodbye, celebration, overwhelm
 
-### Design Principles
+Each board is designed for inclusivity: flexible family slots (not just "Mom and Dad"), cultural adaptability, and age-appropriate tone options.
 
-- **Consistency** - Same actions produce the same results everywhere
-- **Forgiveness** - Undo actions, confirmation for destructive operations
-- **Flexibility** - Multiple ways to accomplish every task
-- **Simplicity** - Core functions are always easy to find
-- **Feedback** - Clear indication of what's happening and what happened
+---
+
+## Why Open Source?
+
+**For families:** No cost barrier. No lock-in. Your boards are yours forever.
+
+**For the community:** Collective ownership. Transparency. The power to improve it.
+
+**What we promise:**
+- Core functionality stays free
+- No selling user data, ever
+- Boards remain portable and open
+- Community voice in major decisions
+
+**What we won't do:**
+- Track your communication
+- Require accounts for basic use
+- Create artificial limitations
+- Abandon or close-source the project
 
 ---
 
 ## How to Contribute
 
-LoveWords is built by a community of developers, designers, speech-language pathologists, AAC users, caregivers, and advocates. We welcome you!
+You don't need to code to help. Here's how to get involved:
 
-### Ways to Help
+### Share Your Experience
+If you use AAC or support someone who does, your perspective is invaluable. Tell us what phrases your family needs, what moments are hardest, what's missing.
 
-#### Share Your Experience
-- **AAC users**: Your lived experience is invaluable. Tell us what works, what doesn't, and what you wish existed.
-- **SLPs & educators**: Share your professional insights on what makes AAC tools effective.
-- **Caregivers & families**: Help us understand the day-to-day realities of AAC use.
+### Create Boards
+Design boards for specific communities: cultural adaptations, translations, different family structures, age-specific vocabulary.
 
-#### Code & Design
-- **Developers**: Check out our issues labeled `good first issue` or `help wanted`
-- **Designers**: We need help with symbols, UI/UX, and making things beautiful and usable
-- **Accessibility experts**: Help us test and improve our accessibility implementation
+### Spread the Word
+Tell families, therapists, and schools who might benefit.
 
-#### Documentation & Translation
-- **Writers**: Help improve our documentation, guides, and tutorials
-- **Translators**: Help make LoveWords available in more languages
-- **Symbol creators**: Design and contribute open-licensed communication symbols
+### Give Feedback
+Try the boards. Tell us what works. Help us improve.
 
-#### Spread the Word
-- Star this repository
-- Share LoveWords with families, therapists, and schools who might benefit
-- Write about your experience using or contributing to LoveWords
-
-### Getting Started
-
-```bash
-# Clone the repository
-git clone https://github.com/your-org/lovewords.git
-
-# Navigate to the project
-cd lovewords
-
-# Install dependencies
-npm install
-
-# Start development server
-npm run dev
-```
-
-### Contribution Guidelines
-
-1. **Be kind and inclusive** - We're building for a vulnerable population. Empathy guides everything.
-2. **Accessibility first** - Every feature must be accessible. No exceptions.
-3. **Test with real users** - When possible, validate changes with AAC users.
-4. **Document your work** - Good documentation helps the next contributor.
-5. **Ask questions** - No question is too small. We're here to help.
-
-### Code of Conduct
-
-We are committed to providing a welcoming and inclusive environment for everyone. All contributors are expected to uphold our Code of Conduct, which centers on respect, empathy, and constructive collaboration.
+### Contribute Code or Design
+Check [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ---
 
-## Join Us
+## The Vision
 
-Building LoveWords isn't just about writing code. It's about believing that everyone has something to say and deserves the tools to say it.
-
-If you've ever felt unheard, if you've watched someone struggle to communicate, if you believe that technology should serve humanity's deepest needs, then this project is for you.
-
-**Every contribution matters. Every voice counts. Including yours.**
+For the full north star vision—including our complete board designs, detailed principles, and elevator pitches—see [docs/VISION.md](docs/VISION.md).
 
 ---
 
 ## License
 
-LoveWords is released under the [GNU General Public License v3.0](LICENSE). This means you're free to use, modify, and distribute this software, as long as any derivative works remain open source under the same license.
-
-We chose GPL-3.0 intentionally: communication tools should remain free and open, forever.
-
----
-
-## Contact & Community
-
-- **Discussions**: GitHub Discussions (coming soon)
-- **Issues**: [GitHub Issues](../../issues) for bugs and feature requests
-- **Email**: lovewords@example.com (placeholder)
+LoveWords is released under the [GNU General Public License v3.0](LICENSE). Communication tools should remain free and open, forever.
 
 ---
 
 <p align="center">
-  <em>Made with love, for everyone who has something to say.</em>
+  <strong>Everyone has something to say.</strong><br>
+  <em>LoveWords helps them say what matters most.</em>
 </p>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -308,6 +308,12 @@ We commit to these guarantees:
 3. **We will not introduce breaking schema forks** — Boards remain portable to other AAC apps
 4. **Import/export is round-trippable** — Boards survive multiple import/export cycles
 
+#### OBF Specification Reference
+
+LoveWords implements **Open Board Format v1.0**:
+- Specification: https://www.openboardformat.org/
+- Schema: https://github.com/openboardformat/oaa
+
 #### LoveWords Extensions (Optional)
 
 These features are stored in namespaced OBF extensions:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -87,7 +87,7 @@ LoveWords uses a **shared Rust core** with **native clients** for each platform.
 │     ┌──────────────┐   ┌──────────────┐   ┌──────────────────┐     │
 │     │ iOS/watchOS  │   │    Chrome    │   │      Tauri       │     │
 │     │    macOS     │   │   Extension  │   │ (Win/Mac/Linux)  │     │
-│     │  (SwiftUI)   │   │   (Svelte)   │   │    (Svelte)      │     │
+│     │  (SwiftUI)   │   │   (React)    │   │    (React)       │     │
 │     └──────────────┘   └──────────────┘   └──────────────────┘     │
 │                                                                      │
 └─────────────────────────────────────────────────────────────────────┘
@@ -178,8 +178,8 @@ Each platform gets its own native client, providing the best possible experience
 | **iOS/iPadOS** | SwiftUI | UniFFI → Swift | AVSpeechSynthesis, VoiceOver, Switch Control |
 | **watchOS** | SwiftUI | UniFFI → Swift | Complications, quick phrases |
 | **macOS** | SwiftUI | UniFFI → Swift | Menu bar, keyboard shortcuts, macOS a11y |
-| **Chrome Extension** | Svelte | wasm-pack | Content scripts, popup UI, Chromebook support |
-| **Tauri Desktop** | Svelte | tauri-bindgen | Cross-platform, system TTS, file access |
+| **Chrome Extension** | React | wasm-pack | Content scripts, popup UI, Chromebook support |
+| **Tauri Desktop** | React | tauri-bindgen | Cross-platform, system TTS, file access |
 
 ### Build Sequence
 
@@ -289,15 +289,36 @@ Board
 | `Backspace` | Remove last item from message bar |
 | `Custom` | Platform-specific action (e.g., open settings) |
 
-### Board Format
+### Board Format — OBF Native
 
-Boards are stored as JSON. We support:
+LoveWords uses Open Board Format (OBF) natively, not as an export-only format:
 
 | Format | Use Case |
 |--------|----------|
-| **LoveWords JSON** | Internal storage, full feature support |
-| **Open Board Format (OBF)** | Import/export for interoperability |
-| **Backup archive** | Complete profile export (.zip) |
+| **Open Board Format (OBF)** | Native storage, full interoperability |
+| **LoveWords Extensions** | Optional namespaced metadata (`lovewords:*`) |
+| **Backup archive** | Complete profile export (.obz with assets) |
+
+#### OBF Compatibility Contract
+
+We commit to these guarantees:
+
+1. **We are OBF-native** — OBF is our source of truth, not a conversion target
+2. **LoveWords metadata is optional and namespaced** — Any extensions use `lovewords:*` prefix
+3. **We will not introduce breaking schema forks** — Boards remain portable to other AAC apps
+4. **Import/export is round-trippable** — Boards survive multiple import/export cycles
+
+#### LoveWords Extensions (Optional)
+
+These features are stored in namespaced OBF extensions:
+
+| Extension | Purpose |
+|-----------|---------|
+| `lovewords:moment` | Grouping for contexts (bedtime, apology, comfort) |
+| `lovewords:warmth` | Intent tags (affection, gratitude, reassurance) |
+| `lovewords:quickSay` | Suggested phrase variants |
+
+**Core principle:** A board never requires LoveWords extensions to render or speak. Extensions enhance, never gate.
 
 ---
 
@@ -476,10 +497,11 @@ All timing is configurable for motor needs:
 |-------|------------|-----------|
 | **Core Language** | Rust | Memory safety, performance, cross-platform |
 | **Core Serialization** | serde + JSON | Portable, debuggable |
+| **Board Format** | Open Board Format (OBF) | Industry standard, interoperability |
 | **iOS/macOS Bindings** | UniFFI | Automatic Swift/Kotlin generation |
 | **Web Bindings** | wasm-pack + wasm-bindgen | WebAssembly for Chrome |
 | **Desktop Framework** | Tauri | Rust backend, web frontend, small binary |
-| **Web UI Framework** | Svelte | Small bundles, simple mental model |
+| **Web UI Framework** | React | Contributor gravity, accessibility patterns |
 | **iOS/macOS UI** | SwiftUI | Modern, declarative, great a11y |
 | **Testing** | cargo test, XCTest, Playwright | Platform-appropriate |
 
@@ -549,7 +571,7 @@ lovewords/
 │   ├── src-tauri/
 │   │   ├── Cargo.toml
 │   │   └── src/
-│   ├── src/                   # Svelte frontend
+│   ├── src/                   # React frontend
 │   └── package.json
 │
 ├── apple/                     # iOS/macOS/watchOS

--- a/docs/DECISION_QUEUE.md
+++ b/docs/DECISION_QUEUE.md
@@ -1,0 +1,261 @@
+# LoveWords Decision Queue
+
+> Decisions pending founder (ChatGPT) input and resolved decisions log
+
+---
+
+## How to Use This Document
+
+**Claude Code:** Add decisions here when founder input is needed. Use the template below.
+
+**User (Relay):** Present pending decisions to ChatGPT using the formatted question.
+
+**After Resolution:** Move decisions to the Resolved section with rationale.
+
+---
+
+## Pending Decisions
+
+<!-- Decisions awaiting ChatGPT input -->
+
+### [DECISION-002] Board Format Standard
+
+**Status:** PENDING_FOUNDER
+**Priority:** HIGH
+**Created:** 2025-01-15
+**Blocking:** Board implementation in Rust core
+
+**Context:**
+We need to choose a format for storing communication boards. This affects portability, community sharing, and integration with other AAC tools.
+
+**Options:**
+
+1. **Option A: Open Board Format (OBF)**
+   - Description: Industry-standard AAC interchange format (.obz/.obf files)
+   - Pros: Interoperability with TouchChat, Proloquo2Go, CoughDrop, and other AAC apps
+   - Cons: May not capture all LoveWords-specific features; format is XML-based
+
+2. **Option B: Custom JSON Format + OBF Export**
+   - Description: Our own JSON format internally, with OBF export/import capability
+   - Pros: Full flexibility for LoveWords features, still portable via export
+   - Cons: More work to maintain both formats
+
+3. **Option C: OBF as Primary with Extensions**
+   - Description: Use OBF natively but extend it with LoveWords-specific fields
+   - Pros: Best of both worlds—compatible and extensible
+   - Cons: Extensions may not transfer to other apps
+
+**Trade-offs:**
+Pure OBF limits innovation in board structure. Custom format risks fragmentation. Extensions balance both but add complexity.
+
+**Claude Code's Recommendation:**
+Option C - OBF as primary with documented extensions. This maximizes interoperability while allowing innovation. Extensions that prove useful could be proposed to the OBF standard.
+
+**Questions for ChatGPT:**
+1. How important is native OBF compatibility vs. feature flexibility?
+2. Should LoveWords aim to influence/extend the OBF standard?
+
+---
+
+### [DECISION-003] Voice Recording Storage
+
+**Status:** PENDING_FOUNDER
+**Priority:** MEDIUM
+**Created:** 2025-01-15
+**Blocking:** Voice recording feature design
+
+**Context:**
+LoveWords allows recording personal voice messages (mom's voice saying "I love you"). Need to decide storage approach.
+
+**Options:**
+
+1. **Option A: Local-Only**
+   - Description: Recordings stored only on device, no cloud
+   - Pros: Maximum privacy, simple, works offline
+   - Cons: Lost if device is lost/replaced, no sharing between devices
+
+2. **Option B: Optional Encrypted Cloud Backup**
+   - Description: Local by default, opt-in E2E encrypted cloud backup
+   - Pros: Recovery possible, sync between devices, still private
+   - Cons: More infrastructure, requires account for backup
+
+3. **Option C: Local + Manual Export**
+   - Description: Local storage with easy export to files/email
+   - Pros: User-controlled backup, no cloud infrastructure needed
+   - Cons: Manual process, less seamless
+
+**Trade-offs:**
+Privacy vs. data safety vs. convenience.
+
+**Claude Code's Recommendation:**
+Option C for v1.0, with Option B as future enhancement. Keeps initial scope simple while preserving privacy.
+
+**Questions for ChatGPT:**
+1. Is cloud backup important enough to build infrastructure for?
+2. How do we balance "don't lose precious recordings" with "no accounts required"?
+
+---
+
+### [DECISION-004] Svelte vs React for Web Frontends
+
+**Status:** PENDING_FOUNDER
+**Priority:** MEDIUM
+**Created:** 2025-01-15
+**Blocking:** Tauri and Chrome extension development
+
+**Context:**
+Need to choose a frontend framework for Tauri desktop app and Chrome extension.
+
+**Options:**
+
+1. **Option A: Svelte**
+   - Description: Lightweight, compiler-based framework
+   - Pros: Smaller bundles, simpler mental model, less boilerplate, growing community
+   - Cons: Smaller ecosystem than React, fewer pre-built components
+
+2. **Option B: React**
+   - Description: Established component library framework
+   - Pros: Huge ecosystem, many AAC-specific components exist, more developers know it
+   - Cons: Larger bundles, more boilerplate, heavier runtime
+
+3. **Option C: Solid.js**
+   - Description: React-like API with Svelte-like compilation
+   - Pros: Best of both worlds technically, fine-grained reactivity
+   - Cons: Smallest ecosystem of the three, newer
+
+**Trade-offs:**
+Ecosystem size vs. simplicity. Contributor familiarity vs. new contributor learning curve.
+
+**Claude Code's Recommendation:**
+Option A (Svelte) - aligns with "simplicity over cleverness" heuristic, produces smaller offline-first bundles, and the simpler mental model helps new contributors.
+
+**Questions for ChatGPT:**
+1. Does ecosystem size or simplicity matter more for LoveWords?
+2. Is React familiarity among potential contributors a significant factor?
+
+---
+
+### [DECISION-005] Commercial Use Case Expansion
+
+**Status:** PENDING_FOUNDER
+**Priority:** LOW
+**Created:** 2025-01-15
+**Blocking:** Nothing immediate
+
+**Context:**
+LoveWords is designed for family AAC use. Should we also design for commercial/workplace contexts?
+
+**Options:**
+
+1. **Option A: Family-Only Focus**
+   - Description: Keep scope to personal/family communication
+   - Pros: Clear focus, simpler product
+   - Cons: Limits potential impact
+
+2. **Option B: Family + Workplace**
+   - Description: Also support neurodiverse employees in workplace settings
+   - Pros: Broader impact, potential sustainability through enterprise
+   - Cons: Risk of scope creep, different user needs
+
+3. **Option C: Family First, Workplace Later**
+   - Description: Nail family use case first, consider workplace as v2.0
+   - Pros: Focused start, clear path for growth
+   - Cons: May miss early design decisions that would help workplace later
+
+**Trade-offs:**
+Focus vs. breadth. Sustainability vs. mission purity.
+
+**Questions for ChatGPT:**
+1. Should LoveWords ever target workplace/commercial use?
+2. What's the relationship between family AAC and workplace accessibility?
+
+---
+
+## Resolved Decisions
+
+<!-- Decisions that have been made -->
+
+### [DECISION-000] Multi-Platform Architecture Approach
+
+**Status:** RESOLVED
+**Decision Date:** 2025-01-15
+**Decided By:** ChatGPT (founder) via planning conversation
+
+**Decision:**
+Use Rust core with native clients for each platform:
+- iOS/iPadOS/watchOS: Swift + SwiftUI with UniFFI bindings
+- macOS: Swift + SwiftUI with UniFFI bindings
+- Chrome Extension: WebAssembly via wasm-pack + Svelte
+- Desktop: Tauri with Svelte frontend
+
+**Rationale:**
+- Rust provides memory-safe, performant core logic that can run anywhere
+- Native clients ensure best platform integration and accessibility
+- Shared core prevents logic duplication and ensures consistency
+
+**Heuristics Captured:**
+- TH-001: Multi-Platform via Rust Core
+
+---
+
+### [DECISION-001] iOS Development Approach
+
+**Status:** RESOLVED
+**Decision Date:** 2025-01-15
+**Decided By:** ChatGPT (founder) via planning conversation
+
+**Decision:**
+Pure Swift + SwiftUI with Rust core via UniFFI bindings (not Flutter or React Native).
+
+**Rationale:**
+- Best accessibility support on iOS comes from native frameworks
+- SwiftUI provides natural platform integration
+- Rust core via UniFFI gives us shared logic without sacrificing native feel
+
+**Heuristics Captured:**
+- TH-004: Native Feel Over Code Sharing
+
+---
+
+### [DECISION-001.1] First Client to Build
+
+**Status:** RESOLVED
+**Decision Date:** 2025-01-15
+**Decided By:** ChatGPT (founder) via planning conversation
+
+**Decision:**
+Tauri desktop app (macOS first, then Windows/Linux) before mobile clients.
+
+**Rationale:**
+- Fastest path to working product
+- Lower barrier for iterating on core + UI together
+- Easier to test accessibility features
+- macOS users can test while iOS app is in development
+
+**Build Sequence:**
+1. Rust Core (lovewords-core)
+2. Tauri Desktop (macOS/Windows/Linux)
+3. iOS/iPadOS
+4. watchOS companion
+5. macOS native (SwiftUI)
+6. Chrome Extension
+
+---
+
+## Decision Log (Chronological)
+
+| ID | Title | Status | Date | Outcome |
+|----|-------|--------|------|---------|
+| DECISION-000 | Multi-Platform Architecture | RESOLVED | 2025-01-15 | Rust core + native clients |
+| DECISION-001 | iOS Development Approach | RESOLVED | 2025-01-15 | Pure Swift + UniFFI |
+| DECISION-001.1 | First Client to Build | RESOLVED | 2025-01-15 | Tauri desktop first |
+| DECISION-002 | Board Format Standard | PENDING | 2025-01-15 | - |
+| DECISION-003 | Voice Recording Storage | PENDING | 2025-01-15 | - |
+| DECISION-004 | Web Framework Choice | PENDING | 2025-01-15 | - |
+| DECISION-005 | Commercial Use Cases | PENDING | 2025-01-15 | - |
+
+---
+
+<p align="center">
+  <em>Good decisions, well documented, create great products.</em>
+</p>

--- a/docs/FOUNDER_INTERFACE.md
+++ b/docs/FOUNDER_INTERFACE.md
@@ -237,11 +237,11 @@ User copies the formatted decision question to ChatGPT conversation.
 
 ### Step 3: ChatGPT Responds
 
-> "Let's go with Svelte. It aligns with our 'simplicity over cleverness' principle,
-> produces smaller bundles which helps with our offline-first approach, and the
-> learning curve is gentler for contributors. React's ecosystem is larger, but
-> we value approachability over ecosystem size. This is consistent with our
-> commitment to being a welcoming project."
+> "Let's go with React. While Svelte is technically elegant, contributor gravity
+> matters more than bundle size right now. React's accessibility patterns for AAC
+> are well-established, and more volunteers can jump in today. We'll enforce
+> simplicity through design system constraints and linting, not framework choice.
+> This supports our 'community over company' principle."
 
 ### Step 4: User Relays Response
 
@@ -252,9 +252,9 @@ User pastes ChatGPT's response to Claude Code.
 Claude Code:
 1. Updates `DECISION_QUEUE.md` with resolved decision
 2. Adds heuristic to `HEURISTICS.md`:
-   - "Choose simpler tools over ecosystem size"
-   - "Approachability for contributors is a priority"
-3. Proceeds with Svelte implementation
+   - "Contributor gravity over technical elegance"
+   - "Enforce simplicity through constraints, not tool choice"
+3. Proceeds with React implementation
 4. Updates related GitHub issues
 
 ---

--- a/docs/FOUNDER_INTERFACE.md
+++ b/docs/FOUNDER_INTERFACE.md
@@ -1,0 +1,289 @@
+# Founder Interface: ChatGPT Collaboration Workflow
+
+> How Claude Code and ChatGPT work together to build LoveWords
+
+---
+
+## Overview
+
+LoveWords uses a unique development model: **Claude Code** handles implementation while **ChatGPT** serves as the product visionary and founder. This document establishes the workflow for their collaboration.
+
+### Roles
+
+| Agent | Role | Responsibilities |
+|-------|------|------------------|
+| **ChatGPT** | Founder/Visionary | Product vision, design decisions, heuristics, priorities |
+| **Claude Code** | Engineer | Implementation, architecture, code, infrastructure |
+| **User** | Relay | Facilitates communication between agents |
+
+---
+
+## Communication Protocol
+
+### How It Works
+
+1. **Claude Code** identifies decisions requiring founder input
+2. **Claude Code** documents the decision in `DECISION_QUEUE.md`
+3. **User** presents the decision to ChatGPT
+4. **ChatGPT** provides direction with rationale
+5. **User** relays response to Claude Code
+6. **Claude Code** implements and captures heuristics in `HEURISTICS.md`
+
+```
+┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+│  Claude Code │ ←→  │     User     │ ←→  │   ChatGPT    │
+│  (Engineer)  │     │   (Relay)    │     │  (Founder)   │
+└──────────────┘     └──────────────┘     └──────────────┘
+       │                                          │
+       │  Creates:                       Provides:
+       │  - Decision Queue               - Decisions
+       │  - Implementation               - Heuristics
+       │  - Architecture                 - Vision
+       │                                 - Priorities
+       ▼                                          ▼
+┌─────────────────────────────────────────────────────────┐
+│                    DECISION_QUEUE.md                     │
+│                    HEURISTICS.md                         │
+│                    GitHub Issues (founder-decision)      │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Question Format for ChatGPT
+
+When presenting decisions to ChatGPT, use this structured format:
+
+### Template
+
+```markdown
+## Decision Required: [DECISION-XXX] Title
+
+**Context:**
+[Brief explanation of what we're building and why this decision matters]
+
+**Options:**
+1. **Option A: [Name]**
+   - Description: [What this entails]
+   - Pros: [Benefits]
+   - Cons: [Drawbacks]
+
+2. **Option B: [Name]**
+   - Description: [What this entails]
+   - Pros: [Benefits]
+   - Cons: [Drawbacks]
+
+3. **Option C: [Name]** (if applicable)
+   - Description: [What this entails]
+   - Pros: [Benefits]
+   - Cons: [Drawbacks]
+
+**Trade-offs:**
+[Key considerations between options]
+
+**Claude Code's Recommendation:**
+[What the engineer recommends and why]
+
+**Questions:**
+1. Which option aligns best with LoveWords' vision?
+2. Are there principles or heuristics to capture for future similar decisions?
+```
+
+### Example
+
+```markdown
+## Decision Required: [DECISION-002] Board Format Standard
+
+**Context:**
+We need to choose a format for storing communication boards. This affects
+portability, community sharing, and integration with other AAC tools.
+
+**Options:**
+1. **Option A: Open Board Format (OBF)**
+   - Description: Industry-standard AAC interchange format
+   - Pros: Interoperability with other AAC apps, established ecosystem
+   - Cons: May not capture all LoveWords-specific features
+
+2. **Option B: Custom LoveWords Format + OBF Export**
+   - Description: Our own format internally, with OBF export capability
+   - Pros: Full flexibility for features, still portable via export
+   - Cons: More work to maintain, potential drift from standard
+
+3. **Option C: JSON-LD with AAC Vocabulary**
+   - Description: Linked data format with AAC-specific schema
+   - Pros: Semantic richness, extensible
+   - Cons: More complex, less tool support
+
+**Trade-offs:**
+Pure OBF means we may limit innovation; custom format means more maintenance.
+
+**Claude Code's Recommendation:**
+Option B - gives us flexibility while maintaining portability.
+
+**Questions:**
+1. How important is native OBF compatibility vs. feature flexibility?
+2. Should we contribute improvements back to the OBF standard?
+```
+
+---
+
+## Processing ChatGPT Responses
+
+When the user relays ChatGPT's response, Claude Code should:
+
+### 1. Extract Decision
+
+```markdown
+## [DECISION-XXX] Title
+**Decision:** [What was decided]
+**Rationale:** [Why this choice was made]
+**Date:** YYYY-MM-DD
+**Source:** ChatGPT conversation relay
+```
+
+### 2. Capture Heuristics
+
+Look for generalizable principles in the response:
+
+```markdown
+## Heuristic: [Short Name]
+**Principle:** [The general rule]
+**Context:** [When this applies]
+**Example:** [How it applied in this decision]
+**Source:** [DECISION-XXX]
+```
+
+### 3. Update GitHub
+
+- Move issue from `founder-decision` to appropriate implementation label
+- Create implementation tasks if needed
+- Link to decision in issue description
+
+---
+
+## Heuristics Capture
+
+### What Are Heuristics?
+
+Heuristics are generalizable decision-making principles extracted from specific ChatGPT decisions. They help Claude Code make future decisions consistently without requiring founder input every time.
+
+### Heuristic Categories
+
+| Category | Examples |
+|----------|----------|
+| **Product** | "Relationship language before functional language" |
+| **Technical** | "Offline-first, always" |
+| **Design** | "Warmth over clinical precision" |
+| **Business** | "Free core, forever" |
+| **Accessibility** | "Every input method gets equal consideration" |
+
+### When to Capture
+
+Capture a heuristic when ChatGPT:
+- States a general principle
+- Explains "we always..." or "we never..."
+- Provides rationale that would apply to similar decisions
+- References LoveWords' core values or mission
+
+---
+
+## Emergency Decisions
+
+For blocking technical decisions where waiting for ChatGPT would stall progress:
+
+### Can Proceed
+
+- Implementation details within decided architecture
+- Bug fixes that don't change behavior
+- Performance optimizations
+- Code quality improvements
+
+### Must Wait
+
+- User-facing feature changes
+- Data format changes
+- Accessibility approach changes
+- Privacy implications
+- Anything that affects the "feel" of LoveWords
+
+### When In Doubt
+
+Default to waiting and document in `DECISION_QUEUE.md` as `URGENT`.
+
+---
+
+## Files This System Uses
+
+| File | Purpose |
+|------|---------|
+| `docs/FOUNDER_INTERFACE.md` | This document - the workflow |
+| `docs/DECISION_QUEUE.md` | Pending and resolved decisions |
+| `docs/HEURISTICS.md` | Captured founder principles |
+| GitHub Issues | `founder-decision` labeled for tracking |
+
+---
+
+## Workflow Example
+
+### Step 1: Claude Code Identifies Decision
+
+> "Should we use Svelte or React for the Tauri desktop frontend?"
+
+Claude Code creates entry in `DECISION_QUEUE.md` with full analysis.
+
+### Step 2: User Presents to ChatGPT
+
+User copies the formatted decision question to ChatGPT conversation.
+
+### Step 3: ChatGPT Responds
+
+> "Let's go with Svelte. It aligns with our 'simplicity over cleverness' principle,
+> produces smaller bundles which helps with our offline-first approach, and the
+> learning curve is gentler for contributors. React's ecosystem is larger, but
+> we value approachability over ecosystem size. This is consistent with our
+> commitment to being a welcoming project."
+
+### Step 4: User Relays Response
+
+User pastes ChatGPT's response to Claude Code.
+
+### Step 5: Claude Code Processes
+
+Claude Code:
+1. Updates `DECISION_QUEUE.md` with resolved decision
+2. Adds heuristic to `HEURISTICS.md`:
+   - "Choose simpler tools over ecosystem size"
+   - "Approachability for contributors is a priority"
+3. Proceeds with Svelte implementation
+4. Updates related GitHub issues
+
+---
+
+## Best Practices
+
+### For Claude Code
+
+- Document decisions **before** asking, not after
+- Provide genuine recommendations with reasoning
+- Capture heuristics immediately while context is fresh
+- Link decisions to GitHub issues for traceability
+
+### For the User (Relay)
+
+- Copy questions verbatim to ChatGPT
+- Capture the full response, including rationale
+- Ask ChatGPT to clarify if the answer is ambiguous
+- Note any follow-up context ChatGPT provides
+
+### For ChatGPT
+
+- Explain the "why" not just the "what"
+- Reference LoveWords principles when relevant
+- Note if this should become a standing heuristic
+- Ask clarifying questions if the options aren't clear
+
+---
+
+<p align="center">
+  <em>Great products come from clear decisions. This workflow ensures every decision is thoughtful, documented, and consistent with our vision.</em>
+</p>

--- a/docs/HEURISTICS.md
+++ b/docs/HEURISTICS.md
@@ -1,0 +1,236 @@
+# LoveWords Founder Heuristics
+
+> Captured decision-making principles from ChatGPT (founder) conversations
+
+---
+
+## How to Use This Document
+
+This document captures generalizable principles extracted from specific founder decisions. When facing a new decision:
+
+1. **Check relevant heuristics** - does an existing principle apply?
+2. **Apply consistently** - use heuristics to make aligned decisions
+3. **When heuristics conflict** - escalate to `DECISION_QUEUE.md` for founder input
+
+---
+
+## Core Principles
+
+### CP-001: Relationship Language First
+**Principle:** Prioritize emotional and relational vocabulary over functional/needs-based vocabulary.
+
+**Context:** When deciding what features to build, what boards to create, or what vocabulary to include.
+
+**Example:** "I love you" gets built before "I need bathroom"—both matter, but relationship language is our differentiator.
+
+**Source:** North Star Vision
+
+---
+
+### CP-002: Free Core, Forever
+**Principle:** Essential communication functionality must remain free with no artificial limitations.
+
+**Context:** Any discussion of monetization, premium features, or business model.
+
+**Example:** Never put basic boards or TTS behind a paywall.
+
+**Source:** North Star Vision
+
+---
+
+### CP-003: Privacy as Default
+**Principle:** Default to no data collection, no accounts, no tracking. Opt-in only for any data sharing.
+
+**Context:** Feature design, analytics, cloud features.
+
+**Example:** No accounts required. Analytics are opt-in. Cloud backup is opt-in with E2E encryption.
+
+**Source:** North Star Vision
+
+---
+
+### CP-004: Offline-First, Always
+**Principle:** Every feature must work without internet. Network is a bonus, not a requirement.
+
+**Context:** Architecture decisions, feature design, storage choices.
+
+**Example:** TTS voices must be downloadable for offline use. Boards stored locally first.
+
+**Source:** North Star Vision
+
+---
+
+## Technical Heuristics
+
+### TH-001: Multi-Platform via Rust Core
+**Principle:** Shared logic lives in Rust; platform-specific code only where necessary.
+
+**Context:** Architecture decisions, new feature implementation.
+
+**Example:** Board navigation logic is in Rust, not duplicated per platform.
+
+**Source:** [DECISION-000] Architecture Approach
+
+**Date:** 2025-01-15
+
+---
+
+### TH-002: Simplicity Over Cleverness
+**Principle:** Choose simpler, more readable solutions over clever optimizations.
+
+**Context:** Code style, library choices, architecture patterns.
+
+**Example:** A straightforward loop is better than a complex one-liner.
+
+**Source:** North Star Vision
+
+---
+
+### TH-003: Approachability for Contributors
+**Principle:** When choosing between equivalent options, prefer the one that's easier for new contributors.
+
+**Context:** Tooling decisions, library choices, documentation.
+
+**Example:** Clear error messages > terse ones. Well-documented APIs > clever abstractions.
+
+**Source:** North Star Vision (open source commitment)
+
+---
+
+### TH-004: Native Feel Over Code Sharing
+**Principle:** For mobile apps, prioritize native platform feel over maximum code reuse.
+
+**Context:** Mobile development approach.
+
+**Example:** iOS app uses SwiftUI with Rust core via UniFFI, not a cross-platform UI framework.
+
+**Source:** [DECISION-001] iOS Development Approach
+
+**Date:** 2025-01-15
+
+---
+
+## Product Heuristics
+
+### PH-001: Warmth Over Clinical
+**Principle:** LoveWords should feel warm, human, and approachable—not medical or institutional.
+
+**Context:** UI design, copy, branding, board content.
+
+**Example:** "Add someone you love" not "Configure user profiles"
+
+**Source:** North Star Vision
+
+---
+
+### PH-002: Moments-Based Organization
+**Principle:** Organize features and boards around when they're used, not what category they belong to.
+
+**Context:** Navigation design, board structure.
+
+**Example:** "Bedtime" board grouping vs. "Feelings" + "Greetings" + "Actions" categorization.
+
+**Source:** North Star Vision
+
+---
+
+### PH-003: Fastest Path to Expression
+**Principle:** Minimize taps/actions between wanting to say something and saying it.
+
+**Context:** UI design, navigation, quick-access features.
+
+**Example:** "I love you, mom" should be reachable in 1-2 taps.
+
+**Source:** North Star Vision
+
+---
+
+### PH-004: Include All Family Structures
+**Principle:** Never assume traditional family structure. Support all caregiving relationships.
+
+**Context:** Board design, personalization features, default vocabulary.
+
+**Example:** "My grown-up" as neutral option alongside Mom, Dad, etc.
+
+**Source:** North Star Vision (Inclusivity section)
+
+---
+
+## Accessibility Heuristics
+
+### AH-001: Every Input Method, Equal Priority
+**Principle:** Touch, switch scanning, eye gaze, and keyboard must all be first-class citizens.
+
+**Context:** UI implementation, feature design.
+
+**Example:** New feature must work with all input methods before shipping.
+
+**Source:** North Star Vision
+
+---
+
+### AH-002: Test With Real Users
+**Principle:** Accessibility testing with actual AAC users, not just automated tools.
+
+**Context:** QA process, release criteria.
+
+**Example:** Beta testing includes families who use AAC daily.
+
+**Source:** North Star Vision (community input commitment)
+
+---
+
+## Business Heuristics
+
+### BH-001: Community Over Company
+**Principle:** LoveWords is a community project that happens to have maintainers, not a company product.
+
+**Context:** Decision-making process, feature prioritization.
+
+**Example:** Major changes require community input before implementation.
+
+**Source:** North Star Vision (open source commitment)
+
+---
+
+### BH-002: Transparency by Default
+**Principle:** When in doubt, share more information rather than less.
+
+**Context:** Communication, documentation, process.
+
+**Example:** Decision rationale documented publicly, not just the decision.
+
+**Source:** North Star Vision (open source commitment)
+
+---
+
+## Adding New Heuristics
+
+When a founder decision reveals a new generalizable principle:
+
+1. **Identify the principle** - What's the underlying rule?
+2. **Define the context** - When does this apply?
+3. **Provide an example** - How did it apply in this case?
+4. **Note the source** - Which decision introduced this?
+5. **Add to appropriate category** above
+
+### Template
+
+```markdown
+### [CATEGORY]-[NUMBER]: [Short Name]
+**Principle:** [The general rule]
+
+**Context:** [When this applies]
+
+**Example:** [How it applied]
+
+**Source:** [DECISION-XXX] or document reference
+
+**Date:** YYYY-MM-DD
+```
+
+---
+
+<p align="center">
+  <em>Consistent decisions build consistent products.</em>
+</p>

--- a/docs/HEURISTICS.md
+++ b/docs/HEURISTICS.md
@@ -110,6 +110,49 @@ This document captures generalizable principles extracted from specific founder 
 
 ---
 
+### TH-005: Contributor Gravity Over Technical Elegance
+**Principle:** When choosing between technically equivalent options, prefer the one that maximizes contributor access.
+
+**Context:** Framework/library choices, tooling decisions, architecture.
+
+**Example:** React chosen over Svelte for web frontends because more volunteers can "jump in today" with React, even though Svelte has technical elegance advantages.
+
+**Guardrails:** Simplicity must still be enforced through design system constraints, linting, and intentionally small component APIs—not by picking a framework with fewer footguns.
+
+**Source:** [DECISION-004] UI Framework Choice
+
+**Date:** 2025-01-16
+
+---
+
+### TH-006: Interoperability as Trust Anchor
+**Principle:** Use industry-standard formats natively, not just as export targets. Portability builds user trust.
+
+**Context:** Data formats, storage decisions, import/export features.
+
+**Example:** LoveWords uses Open Board Format (OBF) natively, not a custom format with OBF export. Users can leave anytime with their boards.
+
+**Corollary:** LoveWords-specific features should be implemented via namespaced extensions that preserve compatibility, never by forking standards.
+
+**Source:** [DECISION-002] Board Format Standard
+
+**Date:** 2025-01-16
+
+---
+
+### TH-007: Relationship-First, Not Format-First
+**Principle:** LoveWords' emotional/relationship focus should show up in the boards we ship and the UX, not by inventing new storage formats or technical differentiators.
+
+**Context:** Feature design, board content, technical architecture.
+
+**Example:** "Love & Affection" board content is our differentiation—not a proprietary board format.
+
+**Source:** [DECISION-002] Board Format Standard
+
+**Date:** 2025-01-16
+
+---
+
 ## Product Heuristics
 
 ### PH-001: Warmth Over Clinical

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -266,7 +266,7 @@ lovewords-chrome/
 - [ ] "My People" photo personalization
 - [ ] Voice recording feature
 - [ ] Profile management (multiple users per device)
-- [ ] Board import/export (OBF compatible, pending [DECISION-002])
+- [ ] Board import/export (OBF v1.0 native per [DECISION-002])
 - [ ] Onboarding flow
 - [ ] Help documentation
 - [ ] Marketing site

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -83,7 +83,7 @@ lovewords-core/
 
 ### Deliverables
 
-- [ ] Initialize Tauri project with Svelte frontend (pending [DECISION-004])
+- [ ] Initialize Tauri project with React frontend
 - [ ] Integrate lovewords-core via Tauri's Rust backend
 - [ ] Build board rendering component
 - [ ] Implement cell selection and message bar
@@ -104,12 +104,12 @@ lovewords-tauri/
 │   │   └── tts.rs          # Platform TTS
 │   └── tauri.conf.json
 ├── src/
-│   ├── App.svelte
+│   ├── App.tsx
 │   ├── components/
-│   │   ├── Board.svelte
-│   │   ├── Cell.svelte
-│   │   ├── MessageBar.svelte
-│   │   └── Settings.svelte
+│   │   ├── Board.tsx
+│   │   ├── Cell.tsx
+│   │   ├── MessageBar.tsx
+│   │   └── Settings.tsx
 │   └── lib/
 │       └── tauri-bridge.ts
 └── package.json
@@ -220,7 +220,7 @@ lovewords-apple/
 
 - [ ] WebAssembly build of lovewords-core
 - [ ] Chrome extension manifest v3
-- [ ] Svelte popup UI
+- [ ] React popup UI
 - [ ] Content script for on-page communication
 - [ ] Keyboard shortcuts
 - [ ] Chromebook accessibility testing
@@ -233,8 +233,8 @@ lovewords-chrome/
 ├── manifest.json
 ├── src/
 │   ├── popup/
-│   │   ├── App.svelte
-│   │   └── main.ts
+│   │   ├── App.tsx
+│   │   └── main.tsx
 │   ├── content/
 │   │   └── content.ts
 │   ├── background/

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,355 @@
+# LoveWords Development Roadmap
+
+> From vision to "I love you, mom" on every device
+
+---
+
+## Overview
+
+This roadmap outlines the path from documentation-only to a fully functional multi-platform AAC application. Each phase builds on the previous, with clear deliverables and success criteria.
+
+```
+Current State: 3,000+ lines of vision/design docs, zero code
+Target State: Working AAC app on desktop, iOS, Chrome, with full accessibility
+```
+
+---
+
+## Phase 1: Foundation (Rust Core)
+
+**Focus:** Build the shared logic that powers all clients
+
+**Milestone:** v0.1 - Core Engine
+
+### Deliverables
+
+- [ ] Initialize Cargo workspace with `lovewords-core` crate
+- [ ] Define Board and Cell data structures
+- [ ] Implement board JSON serialization/deserialization
+- [ ] Create storage trait for platform-agnostic persistence
+- [ ] Define Speech trait for TTS abstraction
+- [ ] Build input event system
+- [ ] Create navigation logic (cell selection, board switching)
+- [ ] First starter boards as JSON (Love & Affection)
+- [ ] Unit tests for all core logic
+- [ ] Documentation with rustdoc
+
+### Crate Structure
+
+```
+lovewords-core/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs              # Public API
+│   ├── board/              # Board model
+│   │   ├── mod.rs
+│   │   ├── cell.rs
+│   │   ├── layout.rs
+│   │   └── navigation.rs
+│   ├── speech/             # TTS abstraction
+│   │   ├── mod.rs
+│   │   ├── trait.rs
+│   │   └── recording.rs
+│   ├── storage/            # Persistence
+│   │   ├── mod.rs
+│   │   ├── profile.rs
+│   │   └── export.rs
+│   ├── input/              # Input system
+│   │   ├── mod.rs
+│   │   ├── event.rs
+│   │   └── scanning.rs
+│   ├── accessibility/      # A11y utilities
+│   │   └── mod.rs
+│   └── symbols/            # Symbol registry
+│       ├── mod.rs
+│       └── registry.rs
+└── tests/
+```
+
+### Success Criteria
+
+- [ ] `cargo build` succeeds
+- [ ] `cargo test` passes with >80% coverage on core logic
+- [ ] Board can be loaded, navigated, and serialized
+- [ ] Speech trait defined with clear platform hook points
+
+---
+
+## Phase 2: First Client (Tauri Desktop)
+
+**Focus:** Proof of concept with working UI
+
+**Milestone:** v0.2 - First Client
+
+### Deliverables
+
+- [ ] Initialize Tauri project with Svelte frontend (pending [DECISION-004])
+- [ ] Integrate lovewords-core via Tauri's Rust backend
+- [ ] Build board rendering component
+- [ ] Implement cell selection and message bar
+- [ ] Add TTS using system voices
+- [ ] Create basic settings panel
+- [ ] Package for macOS (.dmg)
+- [ ] Test with keyboard navigation
+
+### Architecture
+
+```
+lovewords-tauri/
+├── src-tauri/
+│   ├── Cargo.toml          # Depends on lovewords-core
+│   ├── src/
+│   │   ├── main.rs
+│   │   ├── commands.rs     # Tauri commands
+│   │   └── tts.rs          # Platform TTS
+│   └── tauri.conf.json
+├── src/
+│   ├── App.svelte
+│   ├── components/
+│   │   ├── Board.svelte
+│   │   ├── Cell.svelte
+│   │   ├── MessageBar.svelte
+│   │   └── Settings.svelte
+│   └── lib/
+│       └── tauri-bridge.ts
+└── package.json
+```
+
+### Success Criteria
+
+- [ ] User can open app, see a board, tap cells
+- [ ] Message bar shows selected phrases
+- [ ] Speak button plays TTS
+- [ ] Basic keyboard navigation works
+- [ ] App runs offline
+
+---
+
+## Phase 3: Apple Platform
+
+**Focus:** Native iOS experience with full accessibility
+
+**Milestone:** v0.3 - iOS MVP
+
+### Deliverables
+
+- [ ] Set up Xcode project with Swift Package Manager
+- [ ] Generate UniFFI bindings from lovewords-core
+- [ ] Build SwiftUI board view
+- [ ] Implement AVSpeechSynthesis for TTS
+- [ ] Add VoiceOver support
+- [ ] Create Switch Control compatibility
+- [ ] Design for iPad as primary device
+- [ ] iPhone companion app
+- [ ] TestFlight beta distribution
+
+### Architecture
+
+```
+lovewords-apple/
+├── LoveWords.xcodeproj
+├── Shared/                 # Shared code
+│   ├── LoveWordsCore/      # UniFFI Swift bindings
+│   ├── Views/
+│   │   ├── BoardView.swift
+│   │   ├── CellView.swift
+│   │   └── MessageBarView.swift
+│   ├── Services/
+│   │   ├── SpeechService.swift
+│   │   └── StorageService.swift
+│   └── Models/
+├── iOS/                    # iOS-specific
+├── iPadOS/                 # iPad-specific
+└── watchOS/                # Apple Watch
+```
+
+### Success Criteria
+
+- [ ] VoiceOver announces all elements correctly
+- [ ] Switch Control can navigate entire app
+- [ ] TTS speaks with natural voice
+- [ ] Works offline completely
+- [ ] Installs via TestFlight
+
+---
+
+## Phase 4: Accessibility Deep Dive
+
+**Focus:** Full accessibility for all input methods
+
+**Milestone:** v0.4 - Accessibility
+
+### Deliverables
+
+- [ ] Switch scanning with configurable timing
+- [ ] Eye gaze integration (research phase)
+- [ ] High contrast themes
+- [ ] Large text support (Dynamic Type on iOS)
+- [ ] Reduced motion mode
+- [ ] Screen reader optimization audit
+- [ ] User testing with AAC users
+- [ ] Accessibility documentation
+
+### Key Features
+
+| Feature | Description | Priority |
+|---------|-------------|----------|
+| Switch Scanning | Row-column, linear, and group scanning | P0 |
+| Dwell Click | Hold to select for head/eye tracking | P0 |
+| Timing Adjustments | Configurable scan speed, dwell time | P0 |
+| High Contrast | WCAG AAA color contrast | P0 |
+| Large Targets | Minimum 44pt touch targets | P0 |
+| Eye Gaze | Integration with Tobii, etc. | P1 |
+
+### Success Criteria
+
+- [ ] 3 AAC users complete usability testing successfully
+- [ ] All WCAG 2.1 AA criteria met
+- [ ] Switch scanning works reliably
+- [ ] At least one eye gaze system integrated
+
+---
+
+## Phase 5: Chrome Extension
+
+**Focus:** Browser-based access for Chromebooks and shared devices
+
+**Milestone:** v0.5 - Chrome Extension
+
+### Deliverables
+
+- [ ] WebAssembly build of lovewords-core
+- [ ] Chrome extension manifest v3
+- [ ] Svelte popup UI
+- [ ] Content script for on-page communication
+- [ ] Keyboard shortcuts
+- [ ] Chromebook accessibility testing
+- [ ] Chrome Web Store submission
+
+### Architecture
+
+```
+lovewords-chrome/
+├── manifest.json
+├── src/
+│   ├── popup/
+│   │   ├── App.svelte
+│   │   └── main.ts
+│   ├── content/
+│   │   └── content.ts
+│   ├── background/
+│   │   └── service-worker.ts
+│   └── wasm/
+│       └── lovewords_core.wasm
+├── public/
+└── vite.config.ts
+```
+
+### Success Criteria
+
+- [ ] Extension installs from Chrome Web Store
+- [ ] Works offline (service worker)
+- [ ] Chromebook keyboard/switch navigation works
+- [ ] Popup is usable at minimum 300px width
+
+---
+
+## Phase 6: Family Ready
+
+**Focus:** Polish, personalization, and first public release
+
+**Milestone:** v1.0 - Family Ready
+
+### Deliverables
+
+- [ ] All 6 starter boards implemented
+- [ ] "My People" photo personalization
+- [ ] Voice recording feature
+- [ ] Profile management (multiple users per device)
+- [ ] Board import/export (OBF compatible, pending [DECISION-002])
+- [ ] Onboarding flow
+- [ ] Help documentation
+- [ ] Marketing site
+- [ ] App Store submission (iOS)
+- [ ] Public launch
+
+### Starter Boards
+
+| Board | Status |
+|-------|--------|
+| Love & Affection | Phase 1 |
+| Gratitude & Appreciation | Phase 6 |
+| Comfort & Reassurance | Phase 6 |
+| Apology & Repair | Phase 6 |
+| Missing Someone | Phase 6 |
+| Moments (Bedtime, Goodbye, etc.) | Phase 6 |
+
+### Success Criteria
+
+- [ ] 10 families using daily for 2+ weeks
+- [ ] App Store rating ≥4.5
+- [ ] Zero critical bugs
+- [ ] <2s cold start time
+- [ ] Works fully offline
+
+---
+
+## Future Phases (Post-1.0)
+
+### v1.1 - Community
+- Community board library
+- Board sharing/remixing
+- Contributor recognition
+
+### v1.2 - Intelligence
+- Word prediction
+- Frequent phrase learning
+- Context-aware suggestions (all local)
+
+### v1.3 - Integration
+- Open Board Format improvements
+- External switch Bluetooth pairing
+- Smart home integration
+
+### v2.0 - Platform
+- Android support
+- Wear OS
+- Web app (full PWA)
+
+---
+
+## Timeline Visualization
+
+```
+         Phase 1        Phase 2         Phase 3        Phase 4
+         ═══════        ═══════         ═══════        ═══════
+         Rust Core      Tauri           iOS            A11y
+            │              │               │              │
+            ▼              ▼               ▼              ▼
+┌──────────────────────────────────────────────────────────────────┐
+│ ██████████ ▓▓▓▓▓▓▓▓▓▓ ░░░░░░░░░░ ░░░░░░░░░░ ░░░░░░░░░░ ░░░░░░░░░░│
+│ v0.1       v0.2        v0.3        v0.4        v0.5       v1.0   │
+└──────────────────────────────────────────────────────────────────┘
+                                                   ▲          ▲
+                                                   │          │
+                                              Chrome      Family
+                                              Ext.        Ready
+```
+
+---
+
+## Contributing
+
+Each phase has GitHub issues labeled by milestone. Look for:
+- `good-first-issue` - Great starting points
+- `help-wanted` - We need community help
+- `core-rust` - Rust core work
+- `accessibility` - A11y features
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines.
+
+---
+
+<p align="center">
+  <em>Every phase brings us closer to helping families connect.</em>
+</p>

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,0 +1,460 @@
+# LoveWords: North Star Vision
+
+> *"Find the words to say 'I love you, mom.'"*
+
+---
+
+## What LoveWords Is
+
+LoveWords is a communication product for AAC users and their families. It helps a person who can't rely on speech quickly express relationship language—love, gratitude, comfort, apology, and connection—using simple, dependable communication boards and phrases.
+
+This is not another general-purpose AAC app. This is a tool built around a specific truth: **the words that matter most are often the hardest to find.**
+
+---
+
+## Mission Statement
+
+**Give every AAC user an easy, dignified way to express heartfelt connection—especially the words that matter most to family.**
+
+---
+
+## Who LoveWords Is For
+
+**Primary users:**
+- AAC users who want fast access to relationship language
+- Nonspeaking and minimally speaking autistic people
+- Individuals with developmental disabilities, cerebral palsy, apraxia, or acquired conditions affecting speech
+- Anyone who needs support expressing emotion, not just needs
+
+**The people around them:**
+- Parents, siblings, partners, and extended family
+- Caregivers and personal assistants
+- Speech-language pathologists and therapists
+- Educators and school staff
+
+---
+
+## Why Build Yet Another AAC Program?
+
+### 1. Relationship-First Communication
+
+Many AAC tools are excellent at needs: *eat, drink, bathroom, help.* These words are essential—but they're not the whole story.
+
+LoveWords starts from connection:
+- *"I love you"*
+- *"I miss you"*
+- *"Thank you"*
+- *"I'm proud of you"*
+- *"I'm scared"*
+- *"Stay with me"*
+
+This emotional vocabulary can be life-changing for families who have waited years to hear these words.
+
+### 2. Lowest-Friction Experience
+
+Families need something that works immediately. No complex configuration. No weeks of setup. No steep learning curve.
+
+LoveWords should feel welcoming and obvious from the first tap. A parent should be able to hand it to their child and watch them say *"I love you, grandma"* within minutes.
+
+### 3. Board Portability and Openness
+
+Communication boards should be shareable, remixable, and not locked inside one vendor's ecosystem.
+
+LoveWords is open source. Your boards belong to you. Export them, share them, adapt them, take them anywhere.
+
+### 4. Privacy and Trust
+
+Families deserve a tool that doesn't monetize sensitive communication. The words between a parent and child are sacred.
+
+Our default stance:
+- Privacy-first
+- Minimal data collection
+- Transparent behavior
+- No accounts required
+- Works offline
+
+### 5. Designed with Real Moments in Mind
+
+We build for the moments where communication matters most:
+- **Mother's Day:** When a child wants to say something special
+- **Bedtime:** Comfort words and "I love you" before sleep
+- **First day of school:** Reassurance for anxious mornings
+- **After a meltdown:** "I'm sorry" and "I still love you"
+- **After care:** "Thank you for helping me"
+- **Missing someone:** "I wish you were here"
+
+These moments need the right words, quickly, without pressure.
+
+---
+
+## The Promise: What LoveWords Feels Like
+
+- **Warm** — not clinical
+- **Simple** — not overwhelming
+- **Respectful** — of the communicator's agency and dignity
+- **Fast** — usable under stress, in real moments
+- **Predictable** — no surprises, no confusion
+- **Customizable** — without feeling technical
+- **Inclusive** — embracing all family structures, cultures, and languages
+- **Accessible** — usable with different motor and sensory needs
+
+---
+
+## What Success Looks Like
+
+- A child says *"I love you, mom"* independently, in seconds
+- Families report more emotional connection and fewer communication breakdowns
+- A teenager tells their sibling *"I'm proud of you"* after a performance
+- A nonverbal adult expresses *"I miss you, Dad"* during a phone call with a parent who lives far away
+- Therapists and educators adopt LoveWords because it fills a gap nothing else does
+- Community contributors create and share board packs for different cultures, languages, and family structures
+
+---
+
+## Core Product Pillars
+
+### 1. Love & Family Starter Set
+A thoughtfully designed collection of boards and phrases focused on:
+- Affection (*I love you, I like you, You're my favorite*)
+- Reassurance (*It's okay, I'm here, You're safe*)
+- Gratitude (*Thank you, I appreciate you, You helped me*)
+- Connection (*I miss you, I'm thinking of you, I'm happy to see you*)
+
+### 2. Personalization That Feels Human
+- Add "my people" with photos and nicknames
+- Record messages in a loved one's voice
+- Include family phrases, inside jokes, culturally meaningful expressions
+- Adjust for family structure (two moms, grandparent caregivers, foster families)
+
+### 3. Moments-Based Navigation
+Quick access organized by when communication happens:
+- **Bedtime** — comfort, love, goodnight
+- **Goodbye** — see you later, I'll miss you, have a good day
+- **Comfort** — I'm scared, hold me, it's too much
+- **Celebration** — I'm proud of you, you did it, happy birthday
+- **Apology** — I'm sorry, I didn't mean it, can we start over
+- **Overwhelm** — I need a break, too loud, help me
+- **Gratitude** — thank you, you're the best, I appreciate you
+- **Missing someone** — I wish you were here, I'm thinking of you
+
+### 4. Community Board Library
+Families and professionals share curated boards:
+- Open-licensed and remixable
+- Clear attribution and credit
+- Diverse languages and cultural contexts
+- Vetted for quality and inclusivity
+
+### 5. Trust and Safety
+- Privacy-first defaults (no tracking, no accounts required)
+- Transparent content policies
+- Careful, respectful language around vulnerable users
+- No monetization of user communication data—ever
+
+---
+
+## Brand Voice and Tone
+
+**Gentle and hopeful** — not clinical or institutional
+
+**Plain language** — avoid jargon; explain AAC simply and respectfully
+
+**Communicator-centered** — the person using AAC is not "broken"; they are expressing themselves in their own way
+
+**Dignified** — we never talk down to users or their families
+
+---
+
+# Why Open Source?
+
+## Who Benefits
+
+**AAC users and families:**
+- No cost barrier to essential communication
+- No vendor lock-in; your boards are yours forever
+- Confidence that the tool can't disappear or become unaffordable
+
+**Therapists and educators:**
+- Adopt and adapt freely for clients and students
+- Contribute improvements that help everyone
+- Trust that the tool will remain available
+
+**The AAC community:**
+- Collective ownership of something important
+- Transparency about how the tool works
+- Ability to fix problems, not just report them
+
+**Developers and contributors:**
+- Meaningful work that changes lives
+- Learning and collaboration in a supportive community
+- Building something that matters
+
+## What We Will Do
+
+- Keep core functionality free, forever
+- Work offline by default; no internet required
+- Respect user privacy absolutely
+- Make boards portable and exportable in open formats
+- Welcome contributions from everyone: users, families, therapists, developers, designers
+- Maintain clear documentation and welcoming onboarding
+- Listen to the AAC community in every decision
+
+## What We Won't Do
+
+- Sell or monetize user data
+- Require accounts or logins for basic use
+- Create artificial limitations to push paid upgrades
+- Lock boards into proprietary formats
+- Track communication content
+- Make decisions without community input on major changes
+- Abandon the project or relicense it as proprietary
+
+---
+
+# First Boards We Ship
+
+The initial release includes a starter set focused on relationship language. These boards are designed to work immediately, with room for personalization.
+
+## 1. Love & Affection Board
+
+Express love in many ways.
+
+**Example phrases:**
+- I love you
+- I love you so much
+- I like you
+- You're my favorite
+- You make me happy
+- I'm glad you're here
+- You're the best
+- Love you forever
+- Big hugs
+- Kiss
+
+**Personalization:** Add photos of family members so "I love you" can be directed to specific people.
+
+---
+
+## 2. Gratitude & Appreciation Board
+
+Say thank you meaningfully.
+
+**Example phrases:**
+- Thank you
+- Thank you for helping me
+- I appreciate you
+- You're so kind
+- That was nice of you
+- I'm grateful
+- You made my day
+- Thanks for understanding
+- I couldn't do it without you
+- You're amazing
+
+---
+
+## 3. Comfort & Reassurance Board
+
+For moments when someone needs support—or wants to give it.
+
+**Example phrases:**
+- It's okay
+- I'm here
+- You're safe
+- I've got you
+- It will be alright
+- Take your time
+- I understand
+- I'm not going anywhere
+- You're not alone
+- I believe in you
+
+---
+
+## 4. Apology & Repair Board
+
+For making things right.
+
+**Example phrases:**
+- I'm sorry
+- I didn't mean to
+- I made a mistake
+- Can we start over?
+- I feel bad about that
+- Please forgive me
+- I'll try to do better
+- I was wrong
+- I love you even when we fight
+- Can I have a hug?
+
+---
+
+## 5. Missing Someone Board
+
+For when loved ones are far away or gone.
+
+**Example phrases:**
+- I miss you
+- I wish you were here
+- I'm thinking of you
+- I can't wait to see you
+- You're in my heart
+- I miss your hugs
+- When will I see you?
+- I miss home
+- I miss [person name]
+- Thinking of you makes me happy/sad
+
+---
+
+## 6. Moments Quick-Access Boards
+
+### Bedtime Board
+- Goodnight
+- I love you
+- Sweet dreams
+- One more hug
+- Stay with me
+- I'm scared
+- Read to me
+- I'm not tired / I'm so tired
+- Tuck me in
+- See you in the morning
+
+### Goodbye Board
+- Goodbye
+- See you later
+- Have a good day
+- I'll miss you
+- Be safe
+- I'll be back
+- Wait for me
+- I love you, bye
+- Don't go / I don't want you to go
+- See you soon
+
+### Celebration Board
+- I'm so proud of you
+- You did it!
+- Congratulations
+- Happy birthday
+- I knew you could do it
+- Let's celebrate
+- This is amazing
+- You're a star
+- Best day ever
+- I'm happy for you
+
+### Overwhelm & Regulation Board
+- I need a break
+- Too loud
+- Too much
+- Help me
+- I need space
+- I'm overwhelmed
+- Can we stop?
+- Hold me
+- I'm trying
+- I need quiet
+
+---
+
+## Notes on Inclusivity
+
+### Family Structures
+Boards include flexible "person" slots, not assumptions. Instead of only "Mom" and "Dad," users can add:
+- Two moms, two dads
+- Grandparent caregivers
+- Foster parents
+- Aunts, uncles, older siblings as primary caregivers
+- Step-parents and blended family members
+- "My grown-up" or "My person" as neutral options
+
+### Cultural Adaptation
+- Phrases can be adapted for cultural context (e.g., formal vs. informal "you," different expressions of respect)
+- Boards are designed to be translated and localized, not just word-for-word but culturally
+- Community contributions welcome for culture-specific starter sets
+
+### Language Support
+- Initial release in English
+- Architecture designed for easy translation
+- Community-contributed translations prioritized
+- Right-to-left language support planned
+
+### Tone Variations
+- Boards avoid assumptions about communication style
+- Options for more formal or casual expression
+- Age-appropriate variations (a teenager may want different phrasing than a young child)
+
+### Accessibility in Board Design
+- High contrast options
+- Adjustable text and symbol sizes
+- Clear, unambiguous symbols
+- Designed for switch scanning and eye gaze, not just touch
+
+---
+
+# The Elevator Pitches
+
+## Short Pitch (2-3 sentences)
+
+LoveWords helps AAC users say what matters most: *I love you. I'm sorry. Thank you. I miss you.* It's a free, open-source communication tool built around relationship language—the words that connect families. Simple enough to use in seconds, personal enough to feel like home.
+
+---
+
+## Long Pitch (Landing Page Version)
+
+Every family has moments when words matter most. The first "I love you." The bedtime "goodnight" that means "you're safe." The "I'm sorry" that repairs a hard day. The "I miss you" that bridges distance.
+
+For families with AAC users—people who communicate through symbols, boards, or devices rather than speech—these moments can be harder to reach. Many AAC tools focus on needs: *eat, drink, bathroom, help.* Essential words, but not the whole story.
+
+**LoveWords is different.** We start from connection.
+
+LoveWords is a free, open-source communication tool designed specifically for relationship language: love, gratitude, comfort, apology, and reassurance. It's built for the moments that matter—bedtime, goodbyes, celebrations, overwhelm, reconciliation, and missing someone.
+
+No complex setup. No weeks of configuration. No expensive subscriptions. Just a warm, simple tool that helps a child say "I love you, mom" in seconds.
+
+We believe communication is a human right—and that includes the words that bind us together. LoveWords is made by and for the AAC community, with privacy-first defaults, open and portable boards, and a commitment to staying free forever.
+
+**Because everyone deserves to be heard. Especially when it matters most.**
+
+---
+
+# How to Contribute
+
+We're building LoveWords with the community, not just for it. Here's how you can help—no coding required for most contributions.
+
+## Share Your Experience
+If you use AAC, or love someone who does, your perspective is essential. Tell us:
+- What phrases would help your family most?
+- What moments are hardest to navigate?
+- What's missing from the tools you've tried?
+
+## Create Boards
+Design communication boards for specific communities:
+- Cultural adaptations
+- Language translations
+- Specific family structures
+- Age-specific vocabulary
+
+## Spread the Word
+Tell families, therapists, and educators who might benefit. The more people who know about LoveWords, the more families we can help connect.
+
+## Give Feedback
+Try the boards. Tell us what works and what doesn't. Report confusing phrases or missing words. Your feedback shapes everything.
+
+## Contribute Code or Design
+If you're a developer, designer, or accessibility expert, we'd love your help. Check our Contributing Guide for details.
+
+---
+
+## Join Us
+
+We're building something that matters: a tool that helps a child tell their parent "I love you." A bridge between a thought and its expression. A way for families to connect through the words that matter most.
+
+**Everyone has something to say. LoveWords helps them say it.**
+
+---
+
+<p align="center">
+  <em>Made with love, for the words that say it.</em>
+</p>


### PR DESCRIPTION
## Summary

This PR establishes the LoveWords project infrastructure with comprehensive documentation and GitHub project management.

### Documentation Added/Updated

- **VISION.md** - North star vision document defining relationship-first AAC
- **ARCHITECTURE.md** - Complete rewrite from web-first PWA to Rust-core with native clients
- **ROADMAP.md** - 6-phase development plan (v0.1 Core Engine → v1.0 Family Ready)
- **FOUNDER_INTERFACE.md** - ChatGPT collaboration workflow for product decisions
- **DECISION_QUEUE.md** - Pending and resolved founder decisions
- **HEURISTICS.md** - Captured design principles and decision-making guidelines
- **README.md** - Simplified with clearer north star messaging

### GitHub Infrastructure Created

| Type | Count | Details |
|------|-------|---------|
| Milestones | 6 | v0.1 through v1.0 |
| Labels | 10 | core-rust, client-ios, accessibility, founder-decision, etc. |
| Issues | 15 | Foundational work from Rust core to first client |
| Project Board | 1 | LoveWords Development |

### Architecture Shift

The key change is moving from a **web-first PWA (React)** to:

```
Rust Core (lovewords-core)
    ↓
├── iOS/iPadOS (SwiftUI + UniFFI)
├── macOS (SwiftUI + UniFFI)
├── Tauri Desktop (Svelte + tauri-bindgen)
└── Chrome Extension (Svelte + wasm-pack)
```

This enables:
- Native accessibility (Switch Control, VoiceOver)
- Shared logic without duplicating code
- Best performance for AAC responsiveness

### Pending Founder Decisions

4 decisions documented in DECISION_QUEUE.md await ChatGPT input:
1. Board format standard (OBF vs custom)
2. Voice recording storage approach
3. Svelte vs React for web frontends
4. Commercial use case expansion

## Test plan

- [x] All documentation renders correctly on GitHub
- [x] Milestones visible at /milestones
- [x] Labels visible at /labels
- [x] Issues created with proper labels and milestones
- [x] Project board accessible at /projects